### PR TITLE
add feature that allows to set the expiration date when the token is …

### DIFF
--- a/server/token.js
+++ b/server/token.js
@@ -14,7 +14,7 @@ function getIssuer (getUserByName) {
   return function (req, res) {
     getUserByName(req.body.username)
       .then(user => {
-        const token = createToken(user, process.env.JWT_SECRET)
+        const token = createToken(user, process.env.JWT_SECRET, process.env.JWT_EXPIRE_TIME)
         res.json({
           message: 'Authentication successful.',
           token
@@ -42,10 +42,10 @@ function decode (req, res, next) {
   })(req, res, next)
 }
 
-function createToken (user, secret) {
+function createToken (user, secret, expireTime) {
   const token = { ...user }
   delete token.hash
-  return jwt.sign(token, secret, { expiresIn: '1d' })
+  return jwt.sign(token, secret, { expiresIn: expireTime ? expireTime : '1d' })
 }
 
 function getSecret (req, payload, done) {

--- a/tests/server/token.test.js
+++ b/tests/server/token.test.js
@@ -36,61 +36,61 @@ describe('token', () => {
   })
 
   it('getIssuer returns a token with a defined expiration time', (done) => {
-    expect.assertions(1);
+    expect.assertions(1)
     jest.mock('jsonwebtoken', () => ({
       sign: (token, secret, expires) => {
         return {
           token,
           secret,
           expires,
-        };
+        }
       },
-    }));
+    }))
 
-    const jwtExpireTime = '5h';
-    process.env.JWT_EXPIRE_TIME = jwtExpireTime;
-    const token = require('../../server/token');
+    const jwtExpireTime = '5h'
+    process.env.JWT_EXPIRE_TIME = jwtExpireTime
+    const token = require('../../server/token')
     const res = {
       json: ({ token }) => {
-        expect(token.expires.expiresIn).toBe(jwtExpireTime);
+        expect(token.expires.expiresIn).toBe(jwtExpireTime)
         delete process.env.JWT_EXPIRE_TIME
-        done();
+        done()
       },
-    };
+    }
 
     const getUserByName = () => {
-      return Promise.resolve();
-    };
+      return Promise.resolve()
+    }
 
-    token.getIssuer(getUserByName)({ body: {} }, res);
-  });
+    token.getIssuer(getUserByName)({ body: {} }, res)
+  })
 
   it('getIssuer returns a token with a default expiration time', (done) => {
-    expect.assertions(1);
+    expect.assertions(1)
     jest.mock('jsonwebtoken', () => ({
       sign: (token, secret, expires) => {
         return {
           token,
           secret,
           expires,
-        };
+        }
       },
-    }));
+    }))
 
-    const token = require('../../server/token');
+    const token = require('../../server/token')
     const res = {
       json: ({ token }) => {
-        expect(token.expires.expiresIn).toBe('1d');
-        done();
+        expect(token.expires.expiresIn).toBe('1d')
+        done()
       },
-    };
+    }
 
     const getUserByName = () => {
-      return Promise.resolve({});
-    };
+      return Promise.resolve({})
+    }
 
-    token.getIssuer(getUserByName)({ body: {} }, res);
-  });
+    token.getIssuer(getUserByName)({ body: {} }, res)
+  })
   
   it('default expiration time is 1 day', () => {
     jest.mock('jsonwebtoken', () => ({
@@ -99,16 +99,16 @@ describe('token', () => {
           token,
           secret,
           expires,
-        };
+        }
       },
-    }));
+    }))
 
-    const token = require('../../server/token');
+    const token = require('../../server/token')
 
-    const testToken = token.createToken({}, 'test-secret');
+    const testToken = token.createToken({}, 'test-secret')
 
-    expect(testToken.expires.expiresIn).toBe('1d');
-  });
+    expect(testToken.expires.expiresIn).toBe('1d')
+  })
 
   it('decode invokes the express-jwt middleware function', () => {
     expect.assertions(4)

--- a/tests/server/token.test.js
+++ b/tests/server/token.test.js
@@ -35,6 +35,81 @@ describe('token', () => {
     token.getIssuer(getUserByName)(req, res)
   })
 
+  it('getIssuer returns a token with a defined expiration time', (done) => {
+    expect.assertions(1);
+    jest.mock('jsonwebtoken', () => ({
+      sign: (token, secret, expires) => {
+        return {
+          token,
+          secret,
+          expires,
+        };
+      },
+    }));
+
+    const jwtExpireTime = '5h';
+    process.env.JWT_EXPIRE_TIME = jwtExpireTime;
+    const token = require('../../server/token');
+    const res = {
+      json: ({ token }) => {
+        expect(token.expires.expiresIn).toBe(jwtExpireTime);
+        delete process.env.JWT_EXPIRE_TIME
+        done();
+      },
+    };
+
+    const getUserByName = () => {
+      return Promise.resolve();
+    };
+
+    token.getIssuer(getUserByName)({ body: {} }, res);
+  });
+
+  it('getIssuer returns a token with a default expiration time', (done) => {
+    expect.assertions(1);
+    jest.mock('jsonwebtoken', () => ({
+      sign: (token, secret, expires) => {
+        return {
+          token,
+          secret,
+          expires,
+        };
+      },
+    }));
+
+    const token = require('../../server/token');
+    const res = {
+      json: ({ token }) => {
+        expect(token.expires.expiresIn).toBe('1d');
+        done();
+      },
+    };
+
+    const getUserByName = () => {
+      return Promise.resolve({});
+    };
+
+    token.getIssuer(getUserByName)({ body: {} }, res);
+  });
+  
+  it('default expiration time is 1 day', () => {
+    jest.mock('jsonwebtoken', () => ({
+      sign: (token, secret, expires) => {
+        return {
+          token,
+          secret,
+          expires,
+        };
+      },
+    }));
+
+    const token = require('../../server/token');
+
+    const testToken = token.createToken({}, 'test-secret');
+
+    expect(testToken.expires.expiresIn).toBe('1d');
+  });
+
   it('decode invokes the express-jwt middleware function', () => {
     expect.assertions(4)
 

--- a/tutorial/.env.example
+++ b/tutorial/.env.example
@@ -1,2 +1,3 @@
 JWT_SECRET="this-is-a-jwt-test-secret"
+JWT_EXPIRE_TIME = "1d"
 BASE_API_URL="http://localhost:3000/api/v1"


### PR DESCRIPTION
…created otherwise the default value is "1d"

Refer to: https://github.com/don-smith/authenticare/issues/47#issue-624622621

- add environment variable "JWT_EXPIRE_TIME" in .env.example file

- pass it as parameter to "createToken" function in token.js file

- add some tests to token.test.js file to check if:
 	- "getIssuer" function returns a token with a default expiration time
	- "getIssuer" function returns a token with a defined expiration time
	-  the default expiration time is "1d"

@don-smith 